### PR TITLE
Added new touch action support.

### DIFF
--- a/lib/Appium.pm
+++ b/lib/Appium.pm
@@ -194,7 +194,7 @@ has 'touch_actions' => (
     is => 'ro',
     lazy => 1,
     init_arg => undef,
-    handles => [ qw/tap swipe wait moveTo release press longPress/ ],
+    handles => [ qw/tap swipe wait move_to release press long_press/ ],
     default => sub { Appium::TouchActions->new( driver => shift ); }
 );
 

--- a/lib/Appium.pm
+++ b/lib/Appium.pm
@@ -194,7 +194,7 @@ has 'touch_actions' => (
     is => 'ro',
     lazy => 1,
     init_arg => undef,
-    handles => [ qw/tap/ ],
+    handles => [ qw/tap swipe wait moveTo release press longPress/ ],
     default => sub { Appium::TouchActions->new( driver => shift ); }
 );
 
@@ -359,6 +359,21 @@ sub press_keycode {
     };
 
     $params->{metastate} = $metastate if $metastate;
+
+    return $self->_execute_command( $res, $params );
+}
+
+sub perform {
+    
+
+    my ($self, $params ) = @_;
+    
+    my $res     = { command => 'touch_action' };
+	my $actions = $self->{'touch_actions'}->{'perform_actions'}; 
+
+	$params     = {'actions' => $actions}; 
+
+	@{$self->{'touch_actions'}->{'perform_actions'}} = ();
 
     return $self->_execute_command( $res, $params );
 }

--- a/lib/Appium.pm
+++ b/lib/Appium.pm
@@ -369,15 +369,22 @@ sub perform {
     my $self = shift;
     
     my $res     = { command => 'touch_action' };
-	my @actions = @{$self->{'touch_actions'}->{'perform_actions'}}; 
+
+	if (exists $self->{'touch_actions'}->{'perform_actions'}) {
+
+		my @actions = @{$self->{'touch_actions'}->{'perform_actions'}}; 
 
 	my $params  = {'actions' => \@actions}; 
 
 	undef @{$self->{'touch_actions'}->{'perform_actions'}};
 
     return $self->_execute_command( $res, $params );
-}
+	} else {
 
+		return $self->_execute_command( $res );
+	} 
+
+}
 =method long_press_keycode ( keycode, [metastate])
 
 Android only: send a long press keycode to the device. Valid keycodes

--- a/lib/Appium.pm
+++ b/lib/Appium.pm
@@ -366,14 +366,14 @@ sub press_keycode {
 sub perform {
     
 
-    my ($self, $params ) = @_;
+    my $self = shift;
     
     my $res     = { command => 'touch_action' };
-	my $actions = $self->{'touch_actions'}->{'perform_actions'}; 
+	my @actions = @{$self->{'touch_actions'}->{'perform_actions'}}; 
 
-	$params     = {'actions' => $actions}; 
+	my $params  = {'actions' => \@actions}; 
 
-	@{$self->{'touch_actions'}->{'perform_actions'}} = ();
+	undef @{$self->{'touch_actions'}->{'perform_actions'}};
 
     return $self->_execute_command( $res, $params );
 }

--- a/lib/Appium/Commands.pm
+++ b/lib/Appium/Commands.pm
@@ -34,11 +34,11 @@ has 'get_cmds' => (
                 url => 'session/:sessionId/context',
                 no_content_success => 1
             },
-            # touch_action => {
-            #         method => 'POST',
-            #         url => 'session/:sessionId/touch/perform',
-            #         no_content_success => 1
-            #     },
+            touch_action => {
+                method => 'POST',
+                url => 'session/:sessionId/touch/perform',
+                no_content_success => 1
+            },
             #     multi_action => {
             #         method => 'POST',
             #         url => 'session/:sessionId/touch/multi/perform',

--- a/lib/Appium/TouchActions.pm
+++ b/lib/Appium/TouchActions.pm
@@ -5,8 +5,8 @@ use Moo;
 
 has 'driver' => (
     is => 'ro',
-    required => 1,
-    handles => [ qw/prompt/ ]
+    required => 1
+    
 );
 
 =method tap ( $x, $y )

--- a/lib/Appium/TouchActions.pm
+++ b/lib/Appium/TouchActions.pm
@@ -23,24 +23,124 @@ the screen. Values greater than 1 will be interpreted as pixels. (10,
 screen.
 
     # tap in the center of the screen
-    $appium->tap( 0.5, 0.5 )
+    $appium->tap( 0.5, 0.5 )->perform();
 
     # tap a pixel position
-    $appium->tap( 300, 500 );
+    $appium->tap( 300, 500 )->perform();
 
 =cut
 
 sub tap {
     my ($self, @coords) = @_;
 
-    my $params = {
+	my $coordinates = {
+
         x => $coords[0],
         y => $coords[1]
     };
 
-    $self->execute_script('mobile: tap', $params);
+
+    #$self->execute_script('mobile: tap', $params);
+
+	my $params = { 'action' => 'tap' , 'options' => $coordinates };
+
+	push @{$self->{'perform_actions'}}, $params;
 
     return $self->driver;
+}
+
+
+
+sub press {
+	my ($self, @coords) = @_;
+
+
+	my $coordinates = {
+
+        x => $coords[0],
+        y => $coords[1]
+    };
+
+	my $params = { 'action' => 'press' , 'options' => $coordinates };
+
+    push @{$self->{'perform_actions'}}, $params;
+
+    return $self->driver;	
+}
+
+
+sub wait {
+	my ($self, $wait) = @_;
+
+	my $options = {
+		ms => $wait
+	};
+
+	my $params = { 'action' => 'wait' , 'options' => $options };
+
+    push @{$self->{'perform_actions'}}, $params;
+
+    return $self->driver;
+}
+
+
+sub moveTo {
+	my ($self, @coords) = @_;
+
+    my $coordinates = {
+
+        x => $coords[0],
+        y => $coords[1]
+    };
+
+
+	my $params = { 'action' => 'moveTo' , 'options' => $coordinates };
+
+    push @{$self->{'perform_actions'}}, $params;
+
+    return $self->driver;
+		
+}
+
+
+sub release {
+	my ($self, @options) = @_;
+
+	my $options = {};
+
+	my $params = { 'action' => 'release' , 'options' => $options };	
+
+	push @{$self->{'perform_actions'}}, $params;
+ 
+    return $self->driver;
+}
+
+
+sub longPress {
+	my ($self, @coords) = @_;
+
+
+    my $coordinates = {
+
+        x => $coords[0],
+        y => $coords[1],
+		duration => $coords[2]
+    };
+
+    my $params = { 'action' => 'press' , 'options' => $coordinates };
+
+    push @{$self->{'perform_actions'}}, $params;
+
+    return $self->driver;
+}
+
+
+sub swipe {
+
+	my ($self, @coords) = @_;
+
+	return $self->press($coords[0], $coords[1])->wait($coords[4])->moveTo($coords[2], $coords[3])->release();
+
 }
 
 1;

--- a/lib/Appium/TouchActions.pm
+++ b/lib/Appium/TouchActions.pm
@@ -6,7 +6,7 @@ use Moo;
 has 'driver' => (
     is => 'ro',
     required => 1,
-    handles => [ qw/execute_script/ ]
+    handles => [ qw/prompt/ ]
 );
 
 =method tap ( $x, $y )
@@ -39,17 +39,34 @@ sub tap {
         y => $coords[1]
     };
 
-
-    #$self->execute_script('mobile: tap', $params);
-
 	my $params = { 'action' => 'tap' , 'options' => $coordinates };
 
 	push @{$self->{'perform_actions'}}, $params;
 
+
     return $self->driver;
 }
 
+=method press ( $x, $y )
 
+Perform a precise press at a certain location on the device, specified
+either by pixels or percentages. All values are relative to the top
+left of the device - by percentages, (0,0) would be the top left, and
+(1, 1) would be the bottom right.
+
+As per the Appium documentation, values between 0 and 1 will be
+interepreted as percentages. (0.5, 0.5) will click in the center of
+the screen. Values greater than 1 will be interpreted as pixels. (10,
+10) will click at ten pixels away from the top and left edges of the
+screen.
+
+    # press in the center of the screen
+    $appium->press( 0.5, 0.5 )->perform();
+
+    # press a pixel position
+    $appium->press( 300, 500 )->perform();
+
+=cut
 
 sub press {
 	my ($self, @coords) = @_;
@@ -68,6 +85,14 @@ sub press {
     return $self->driver;	
 }
 
+=method wait ( $x, $y )
+
+Perform a wait action, specified duration in miliseconds
+
+    #wait for action to complete
+    $appium->wait( 1000 )->perform();
+
+=cut
 
 sub wait {
 	my ($self, $wait) = @_;
@@ -84,7 +109,28 @@ sub wait {
 }
 
 
-sub moveTo {
+=method move_to ( $x, $y )
+
+Perform a precise move_to at a certain location on the device, specified
+either by pixels or percentages. All values are relative to the top
+left of the device - by percentages, (0,0) would be the top left, and
+(1, 1) would be the bottom right.
+
+As per the Appium documentation, values between 0 and 1 will be
+interepreted as percentages. (0.5, 0.5) will click in the center of
+the screen. Values greater than 1 will be interpreted as pixels. (10,
+10) will click at ten pixels away from the top and left edges of the
+screen.
+
+    # move_to in the center of the screen
+    $appium->move_to( 0.5, 0.5 )->perform();
+
+    # move_to a pixel position
+    $appium->move_to( 300, 500 )->perform();
+
+=cut
+
+sub move_to {
 	my ($self, @coords) = @_;
 
     my $coordinates = {
@@ -103,6 +149,15 @@ sub moveTo {
 }
 
 
+=method release ( )
+
+Perform a release aciton, no argument specified
+
+    # release after any action
+    $appium->release()->perform();
+
+=cut
+
 sub release {
 	my ($self, @options) = @_;
 
@@ -115,31 +170,66 @@ sub release {
     return $self->driver;
 }
 
+=method long_press ( $x, $y )
 
-sub longPress {
-	my ($self, @coords) = @_;
+Perform a precise tap at a certain location on the device, specified
+either by pixels or percentages. All values are relative to the top
+left of the device - by percentages, (0,0) would be the top left, and
+(1, 1) would be the bottom right.
+
+As per the Appium documentation, values between 0 and 1 will be
+interepreted as percentages. (0.5, 0.5) will click in the center of
+the screen. Values greater than 1 will be interpreted as pixels. (10,
+10) will click at ten pixels away from the top and left edges of the
+screen.
+
+Specify the duration in miliseconds
+
+    # long press in the center of the screen
+    $appium->long_press( 0.5, 0.5, 1000 )->perform();
+
+    # long press a pixel position
+    $appium->long_press( 300, 500, 1000 )->perform();
+
+=cut
 
 
-    my $coordinates = {
+sub long_press {
+	my ($self, @params) = @_;
 
-        x => $coords[0],
-        y => $coords[1],
-		duration => $coords[2]
+
+    my $options = {
+
+        x => $params[0],
+        y => $params[1],
+		duration => $params[2]
     };
 
-    my $params = { 'action' => 'press' , 'options' => $coordinates };
+    my $final_params = { 'action' => 'press' , 'options' => $options };
 
-    push @{$self->{'perform_actions'}}, $params;
+    push @{$self->{'perform_actions'}}, $final_params;
 
     return $self->driver;
 }
 
 
+=method swipe ( $x, $y )
+
+Perform a precise swipe at a certain location on the device, specified
+start_x, start_y, wait_time,end_x,end_y
+
+
+    # swipe right to left 
+    $appium->swipe( 0.9, 0.5, 1000, 0.1, 0.5 )->perform();
+
+
+=cut
+
 sub swipe {
 
 	my ($self, @coords) = @_;
 
-	return $self->press($coords[0], $coords[1])->wait($coords[4])->moveTo($coords[2], $coords[3])->release();
+	return $self->press($coords[0], $coords[1])->wait($coords[4])->move_to($coords[2], $coords[3])->release();
 
 }
 

--- a/t/Commands.t
+++ b/t/Commands.t
@@ -39,6 +39,7 @@ my @implemented = qw/
                         is_locked
                         network_connection
                         open_notifications
+					    perform
                         press_keycode
                         pull_file
                         pull_folder

--- a/t/TouchActions.t
+++ b/t/TouchActions.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;
@@ -16,10 +16,11 @@ my $actions;
     package FakeAppium;
 
     use Moo;
-    sub execute_script {
-        my ($self, $action, $json) = @_;
+    sub perform {
+		
+		my ($self, $params ) = @_;
+		my $actions = $self->{'touch_actions'}->{'perform_actions'};
 
-        $actions->{$action} = $json;
     }
 }
 
@@ -31,11 +32,11 @@ my $ta = Appium::TouchActions->new(
 
 TOUCH_ACTIONS: {
     my ($x, $y) = (0.2, 0.2);
-    $ta->tap( $x, $y );
+    $ta->tap( $x, $y )->perform();
 
-    ok(exists $actions->{'mobile: tap'}, 'we send the correct javascript for precise taps');
-    is($actions->{'mobile: tap'}->{x}, $x, 'with the correct x coords');
-    is($actions->{'mobile: tap'}->{y}, $y, 'with the correct y coords');
+    ok(exists $actions->{'action'}->{'tap'}, 'we perform precise taps');
+    is($actions->{'options'}->{x}, $x, 'with the correct x coords');
+    is($actions->{'options'}->{y}, $y, 'with the correct y coords');
 
 }
 

--- a/t/TouchActions.t
+++ b/t/TouchActions.t
@@ -18,8 +18,13 @@ my $actions;
     use Moo;
     sub perform {
 		
-		my ($self, $params ) = @_;
-		my $actions = $self->{'touch_actions'}->{'perform_actions'};
+		my $self = shift;
+		my $test = shift;
+		 
+		$actions = ${$test->{'perform_actions'}}[0];
+
+		
+		undef @{$test->{'perform_actions'}};
 
     }
 }
@@ -30,13 +35,71 @@ my $ta = Appium::TouchActions->new(
     driver => $fake_appium
 );
 
-TOUCH_ACTIONS: {
-    my ($x, $y) = (0.2, 0.2);
-    $ta->tap( $x, $y )->perform();
 
-    ok(exists $actions->{'action'}->{'tap'}, 'we perform precise taps');
-    is($actions->{'options'}->{x}, $x, 'with the correct x coords');
-    is($actions->{'options'}->{y}, $y, 'with the correct y coords');
+
+TOUCH_ACTIONS: {
+
+	TAP:{
+
+		my ($x, $y) = (0.2, 0.2);
+		$ta->tap( $x, $y )->perform($ta);
+
+		is($actions->{'action'}, 'tap', 'we perform precise taps');
+		is($actions->{'options'}->{x}, $x, 'with the correct x coords');
+		is($actions->{'options'}->{y}, $y, 'with the correct y coords');
+	}
+
+	PRESS:{
+
+		my ($x, $y) = (0.2, 0.2);
+        $ta->press( $x, $y )->perform($ta);
+
+		is($actions->{'action'}, 'press', 'we perform press action');
+		is($actions->{'options'}->{x}, $x, 'with the correct x coords');
+        is($actions->{'options'}->{y}, $y, 'with the correct y coords');
+	}
+
+	WAIT:{
+
+		my $wait = 1000;
+		$ta->wait($wait)->perform($ta);
+
+		is($actions->{'action'}, 'wait', 'we perform wait action');
+		is($actions->{'options'}->{ms}, $wait, 'with the correct wait time');
+
+	}
+
+	MOVE_TO:{
+
+		my ($x, $y) = (0.2, 0.2);
+        $ta->move_to( $x, $y )->perform($ta);
+
+		is($actions->{'action'}, 'moveTo', 'we perform move_to action');
+		is($actions->{'options'}->{x}, $x, 'with the correct x coords');
+        is($actions->{'options'}->{y}, $y, 'with the correct y coords');
+
+	}
+
+	RELEASE:{
+
+		$ta->release()->perform($ta);
+		
+		is($actions->{'action'}, 'release', 'we perform release action');
+	}
+
+	LONG_PRESS:{
+
+		my ($x, $y, $dur) = (0.2, 0.2, 1000);
+        $ta->long_press( $x, $y, $dur )->perform($ta);
+
+		is($actions->{'action'}, 'press', 'we perform press action');
+		is($actions->{'options'}->{x}, $x, 'with the correct x coords');
+        is($actions->{'options'}->{y}, $y, 'with the correct y coords');
+        is($actions->{'options'}->{duration}, $dur, 'with the correct time');
+
+		
+	}
+
 
 }
 


### PR DESCRIPTION
test added for only tap touch action. Please review.

Need to add element id as the first argument to all touch actions, 
Touch action methods will accept either element-id (el) , or x and y coordinates (x, y) or all (el, x, y) 

x and y coordinates (x, y) this is completed.